### PR TITLE
Fix unicycler tool for unicycler 0.2.0 bioconda package.

### DIFF
--- a/tools/unicycler/unicycler.xml
+++ b/tools/unicycler/unicycler.xml
@@ -1,7 +1,6 @@
 <tool id="unicycler" name="Create assemblies with Unicycler" version="0.2.0">
     <requirements>
          <requirement type="package" version="0.2.0">unicycler</requirement>
-         <requirement type="package" version="3.5">python</requirement>
     </requirements>
     <stdio>
         <exit_code range="1:" />
@@ -50,7 +49,7 @@
 
     ## Get location for pilon installation
 
-        pilon=`which pilon` &&
+        pilon=`pilon --jar_dir` &&
 
     #if $long_reads:
         #if $long_reads.is_of_type('fastqsanger'):
@@ -118,6 +117,10 @@
         #elif $long_reads.is_of_type('fasta'):
             -l lr.fasta
         #end if
+
+    #else
+
+        --no_long
 
     #end if
 
@@ -284,6 +287,17 @@
                 </assert_contents>
             </output>
         </test>
+        <!--
+            Following test corresponds to the command:
+
+              unicycler -t "${GALAXY_SLOTS:-8}"  -o ./ - -verbose 3 - -pilon_path `pilon - -jar_dir` \
+                        -1 test-data/phix_f.fq.gz  -2 test-data/phix_r.fq.gz  -l test-data/onp.fa \
+                         - -mode 'normal' - -no_correct
+
+            This command causes a segfault with the current version of unicycler on bioconda for Linux
+            during the minimap step (which seems to be compiled C code). A gist of the log can be found
+            at: https://gist.github.com/jmchilton/b411b695170c1daea6589f5d76e326cb.
+        -->
         <test>
             <param name="fastq_input_selector" value="paired" />
             <param name="fastq_input1" value="phix_f.fq.gz" ftype="fastqsanger" />


### PR DESCRIPTION
Ping @bgruening @nekrut 

The pilon trick and the no_long option seem to work for me with the bioconda Unicycler. Maybe you are using a dev version that is different than 0.2.0 for testing?

With this PR this wrapper essentially works semantically with unicycler that is on bioconda and the first test passes, but the second test fails at the minimap step - a machine instruction fault. Here is a log of that second test case - https://gist.github.com/jmchilton/b411b695170c1daea6589f5d76e326cb - I get essentially the same thing whether running it directly or using the tool wrapper via Planemo.

Any clue based on that log if that is a problem with this version of unicycler or with the bioconda packages? My next step would be to install unicycler outside of Conda and see if I can reproduce that problem.